### PR TITLE
added strcasecmp and strncasecmp for the mingw build

### DIFF
--- a/base/stringutil.cpp
+++ b/base/stringutil.cpp
@@ -20,9 +20,37 @@
 #include "base/buffer.h"
 #include "base/stringutil.h"
 
+#if defined(__MINGW32__)
+int mw_strcasecmp(const char *s1, const char *s2)
+{
+  while (*s1 && *s2)
+  {
+    int cmp = tolower(*s1++) - tolower(*s2++);
+    if (cmp) return cmp;
+  }
+  
+  return tolower(*s1) - tolower(*s2);
+}
+
+int mw_strncasecmp(const char *s1, const char *s2, size_t n)
+{
+  if (n)
+  {
+    while (*s1 && *s2 && n--)
+    {
+      int cmp = tolower(*s1++) - tolower(*s2++);
+      if (cmp) return cmp;
+    }
+    
+    return tolower(*s1) - tolower(*s2);
+  }
+  
+  return 0;
+}
+#endif
+
 #ifdef _WIN32_NO_MINGW
 // Function Cross-Compatibility
-#define strcasecmp _stricmp
 
 void OutputDebugStringUTF8(const char *p) {
 	wchar_t temp[2048];

--- a/base/stringutil.h
+++ b/base/stringutil.h
@@ -10,8 +10,20 @@
 
 #include "base/basictypes.h"
 
-#ifdef _MSC_VER
+#if defined(__MINGW32__)
+#define strcasecmp mw_strcasecmp
+#define strncasecmp mw_strncasecmp
+#ifdef __cplusplus
+extern "C" {
+#endif
+int mw_strcasecmp(const char *s1, const char *s2);
+int mw_strncasecmp(const char *s1, const char *s2, size_t n);
+#ifdef __cplusplus
+}
+#endif
+#elif defined(_MSC_VER)
 #pragma warning (disable:4996)
+#define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #endif
 


### PR DESCRIPTION
For some unknown reason mingw is generating an infinite loop for strncasecmp, which is defined as _strnicmp, for -O2 and -O3.

These changes add custom versions of strncasecmp and strcasecmp.